### PR TITLE
Refactor todo UI state to use signals

### DIFF
--- a/src/app/components/add-new-pi-dialog/add-new-pi-dialog.ts
+++ b/src/app/components/add-new-pi-dialog/add-new-pi-dialog.ts
@@ -1,5 +1,5 @@
 import { DIALOG_DATA } from '@angular/cdk/dialog';
-import { Component, inject, input } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
   AbstractControl,
   FormControl,
@@ -45,8 +45,6 @@ export function duplicatePiValidator(pis: string[]): ValidatorFn {
 })
 export class AddNewPiDialog {
   data = inject<AddNewPiDialogData>(DIALOG_DATA);
-
-  readonly pis = input<string[]>([]);
 
   formGroup: FormGroup<{
     formControl: FormControl<string>;

--- a/src/app/components/add-new-sprint-dialog/add-new-sprint-dialog.ts
+++ b/src/app/components/add-new-sprint-dialog/add-new-sprint-dialog.ts
@@ -1,5 +1,5 @@
 import { DIALOG_DATA } from '@angular/cdk/dialog';
-import { Component, inject, input } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
   AbstractControl,
   FormControl,
@@ -45,8 +45,6 @@ export function duplicateSprintValidator(sprints: number[]): ValidatorFn {
 })
 export class AddNewSprintDialog {
   data = inject<AddNewSprintDialogData>(DIALOG_DATA);
-
-  readonly sprints = input<number[]>([]);
 
   formGroup: FormGroup<{
     formControl: FormControl<number>;

--- a/src/app/components/base-todo-items/base-todo-items.html
+++ b/src/app/components/base-todo-items/base-todo-items.html
@@ -1,24 +1,24 @@
 <div>
   <h2>{{ title() }}</h2>
   <div>
-    @if (items === undefined) {
+    @if (items() === undefined) {
       <mat-progress-bar mode="indeterminate" />
     }
-    @if (items !== undefined) {
+    @if (items() !== undefined) {
       <mat-accordion [multi]="true" displayMode="default">
-        @if (!this.archive()) {
+        @if (!archive()) {
           <mat-slide-toggle
             id="hideCompletedTasks"
-            [checked]="hideCompletedTasks"
+            [checked]="hideCompletedTasks()"
             (change)="handleHideTasks($event)"
             >Hide completed tasks</mat-slide-toggle
           >
         }
-        @if (items.size === 0) {
+        @if (items()!.size === 0) {
           <p>No items found</p>
         }
-        @if (items.size > 0) {
-          @for (item of items; track item[0]; let index = $index) {
+        @if (items()!.size > 0) {
+          @for (item of items()!; track item[0]; let index = $index) {
             <mat-expansion-panel [expanded]="true" class="white-border">
               <mat-expansion-panel-header>
                 <mat-panel-title>PI {{ item[0] }}</mat-panel-title>
@@ -68,7 +68,7 @@
                           aria-label="expand row"
                           (click)="handleRowExpansion($event, element, true)"
                         >
-                          @if (expandedElementId === element['id']) {
+                          @if (expandedElementId() === element['id']) {
                             <mat-icon>keyboard_arrow_up</mat-icon>
                           } @else {
                             <mat-icon>keyboard_arrow_down</mat-icon>
@@ -77,7 +77,7 @@
                       </td>
                     </ng-container>
 
-                    @if (!this.archive()) {
+                    @if (!archive()) {
                       <ng-container matColumnDef="archive">
                         <th mat-header-cell *matHeaderCellDef aria-label="row actions">Archive</th>
                         <td mat-cell *matCellDef="let element">
@@ -97,12 +97,12 @@
                       <td
                         mat-cell
                         *matCellDef="let element"
-                        [attr.colspan]="columnsToDisplayWithExpand.length"
+                        [attr.colspan]="columnsToDisplayWithExpand().length"
                       >
                         <div
                           class="example-element-detail"
                           [class.example-element-detail-expanded]="
-                            element['id'] === expandedElementId
+                            element['id'] === expandedElementId()
                           "
                         >
                           <div class="example-element-detail-content">
@@ -112,12 +112,12 @@
                       </td>
                     </ng-container>
 
-                    <tr mat-header-row *matHeaderRowDef="columnsToDisplayWithExpand"></tr>
+                    <tr mat-header-row *matHeaderRowDef="columnsToDisplayWithExpand()"></tr>
                     <tr
                       mat-row
-                      *matRowDef="let element; columns: columnsToDisplayWithExpand"
+                      *matRowDef="let element; columns: columnsToDisplayWithExpand()"
                       class="example-element-row"
-                      [class.example-expanded-row]="expandedElementId === element['id']"
+                      [class.example-expanded-row]="expandedElementId() === element['id']"
                       (click)="handleRowExpansion($event, element)"
                     ></tr>
                     <tr

--- a/src/app/components/base-todo-items/base-todo-items.spec.ts
+++ b/src/app/components/base-todo-items/base-todo-items.spec.ts
@@ -61,20 +61,20 @@ describe('BaseTodoItems', () => {
   it('should add archive column when not in archive mode', () => {
     fixture.detectChanges();
     flushInit();
-    expect(component.columnsToDisplayWithExpand).toContain('archive');
+    expect(component.columnsToDisplayWithExpand()).toContain('archive');
   });
 
   it('should NOT add archive column when in archive mode', () => {
     fixture.componentRef.setInput('archive', true);
     fixture.detectChanges();
     flushInit(true);
-    expect(component.columnsToDisplayWithExpand).not.toContain('archive');
+    expect(component.columnsToDisplayWithExpand()).not.toContain('archive');
   });
 
   it('should start with hideCompletedTasks=true', () => {
     fixture.detectChanges();
     flushInit();
-    expect(component.hideCompletedTasks).toBe(true);
+    expect(component.hideCompletedTasks()).toBe(true);
   });
 
   it('should emit pis output with data from metadataApiService', () => {
@@ -110,11 +110,11 @@ describe('BaseTodoItems', () => {
     httpMock.expectOne(`${metaBase}/pis`).flush([]);
     httpMock.expectOne(`${metaBase}/sprints`).flush([]);
 
-    expect(component.items).toBeDefined();
-    expect(component.items?.has('PI1')).toBe(true);
-    expect(component.items?.get('PI1')?.has(1)).toBe(true);
-    expect(component.items?.get('PI1')?.get(1)).toHaveLength(1);
-    expect(component.items?.get('PI2')?.get(3)).toHaveLength(1);
+    expect(component.items()).toBeDefined();
+    expect(component.items()?.has('PI1')).toBe(true);
+    expect(component.items()?.get('PI1')?.has(1)).toBe(true);
+    expect(component.items()?.get('PI1')?.get(1)).toHaveLength(1);
+    expect(component.items()?.get('PI2')?.get(3)).toHaveLength(1);
   });
 
   it('should subscribe to refreshTodoItems and re-fetch when emitted', () => {
@@ -155,14 +155,14 @@ describe('BaseTodoItems', () => {
 
     it('should update hideCompletedTasks and re-fetch items', () => {
       component.handleHideTasks({ checked: false } as MatSlideToggleChange);
-      expect(component.hideCompletedTasks).toBe(false);
+      expect(component.hideCompletedTasks()).toBe(false);
       httpMock.expectOne(`${apiBase}/itemsByPiAndBySprint?hideCompleted=false`).flush({});
     });
 
     it('should re-fetch with hideCompleted=true when toggled back on', () => {
-      component.hideCompletedTasks = false;
+      component.hideCompletedTasks.set(false);
       component.handleHideTasks({ checked: true } as MatSlideToggleChange);
-      expect(component.hideCompletedTasks).toBe(true);
+      expect(component.hideCompletedTasks()).toBe(true);
       httpMock.expectOne(`${apiBase}/itemsByPiAndBySprint?hideCompleted=true`).flush({});
     });
   });
@@ -182,20 +182,20 @@ describe('BaseTodoItems', () => {
     it('should set expandedElementId to the element id on first click', () => {
       const item = makeTodoItem({ id: 42 });
       component.handleRowExpansion(makeEvent('row-button'), item);
-      expect(component.expandedElementId).toBe(42);
+      expect(component.expandedElementId()).toBe(42);
     });
 
     it('should collapse (set to undefined) when clicking the same element again', () => {
       const item = makeTodoItem({ id: 42 });
       component.handleRowExpansion(makeEvent('row-button'), item);
       component.handleRowExpansion(makeEvent('row-button'), item);
-      expect(component.expandedElementId).toBeUndefined();
+      expect(component.expandedElementId()).toBeUndefined();
     });
 
     it('should ignore events triggered by the completed-checkbox', () => {
       const item = makeTodoItem({ id: 42 });
       component.handleRowExpansion(makeEvent('completed-checkbox-1'), item);
-      expect(component.expandedElementId).toBeUndefined();
+      expect(component.expandedElementId()).toBeUndefined();
     });
 
     it('should call stopPropagation when stopPropagation is true', () => {

--- a/src/app/components/base-todo-items/base-todo-items.ts
+++ b/src/app/components/base-todo-items/base-todo-items.ts
@@ -1,12 +1,14 @@
 import {
-  ChangeDetectorRef,
   Component,
-  OnDestroy,
+  DestroyRef,
   OnInit,
+  computed,
   inject,
   input,
   output,
+  signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -14,7 +16,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSlideToggleChange, MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTableModule } from '@angular/material/table';
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { TodoItem } from '../../interfaces/todo-item';
 import { Api } from '../../services/api';
 import { MetadataApi } from '../../services/metadata-api';
@@ -36,50 +38,43 @@ import { TodoItemComponent } from '../todo-item/todo-item';
   templateUrl: './base-todo-items.html',
   styleUrl: './base-todo-items.scss',
 })
-export class BaseTodoItems implements OnInit, OnDestroy {
+export class BaseTodoItems implements OnInit {
   private readonly apiService = inject(Api);
   private readonly metadataApiService = inject(MetadataApi);
-  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
-  private eventsSubscription?: Subscription;
   readonly title = input<string>('');
   readonly archive = input<boolean>(false);
   readonly refreshTodoItems = input<Observable<void> | undefined>();
   readonly pis = output<string[]>();
   readonly sprints = output<number[]>();
 
-  columnsToDisplay = ['title', 'jiraUrl'];
-  columnsToDisplayWithExpand = ['completed', ...this.columnsToDisplay, 'expand'];
-  expandedElementId?: number;
+  readonly columnsToDisplay = ['title', 'jiraUrl'];
+  readonly columnsToDisplayWithExpand = computed(() => {
+    const cols = ['completed', ...this.columnsToDisplay, 'expand'];
+    return this.archive() ? cols : [...cols, 'archive'];
+  });
 
-  items?: Map<string, Map<number, TodoItem[]>>;
-  expandedIndex = 0;
-  hideCompletedTasks = true;
+  readonly items = signal<Map<string, Map<number, TodoItem[]>> | undefined>(undefined);
+  readonly expandedElementId = signal<number | undefined>(undefined);
+  readonly hideCompletedTasks = signal(true);
 
   ngOnInit() {
     this.getTodoItems();
     const refreshTodoItemsObservable = this.refreshTodoItems();
     if (refreshTodoItemsObservable !== undefined) {
-      this.eventsSubscription = refreshTodoItemsObservable.subscribe(() => this.getTodoItems());
-    }
-
-    if (!this.archive()) {
-      this.columnsToDisplayWithExpand = [...this.columnsToDisplayWithExpand, 'archive'];
+      refreshTodoItemsObservable
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.getTodoItems());
     }
 
     this.metadataApiService.getAllPis().subscribe((pis) => this.pis.emit(pis));
     this.metadataApiService.getAllSprints().subscribe((sprints) => this.sprints.emit(sprints));
   }
 
-  ngOnDestroy() {
-    if (this.eventsSubscription !== undefined) {
-      this.eventsSubscription.unsubscribe();
-    }
-  }
-
   getTodoItems() {
     this.apiService
-      .getTodoItemsByPiAndBySprint(this.hideCompletedTasks, this.archive())
+      .getTodoItemsByPiAndBySprint(this.hideCompletedTasks(), this.archive())
       .subscribe((response) => {
         const newItemsMap = new Map<string, Map<number, TodoItem[]>>();
 
@@ -91,8 +86,7 @@ export class BaseTodoItems implements OnInit, OnDestroy {
           }
           newItemsMap.set(pi, sprintMap);
         }
-        this.items = newItemsMap;
-        this.cdr.markForCheck();
+        this.items.set(newItemsMap);
       });
   }
 
@@ -108,7 +102,7 @@ export class BaseTodoItems implements OnInit, OnDestroy {
   handleRowExpansion(event: Event, element: TodoItem, stopPropagation = false) {
     console.log('Row expansion', event, element, stopPropagation);
 
-    // Check if event target id contains completed-checkbox, If it does, ignore the event (but still stop propagation if desired)
+    // Check if event target id contains completed-checkbox; if so, ignore (but still stop propagation if desired)
     if ((event.target as HTMLElement).id.includes('completed-checkbox')) {
       console.log('Ignoring row expansion event because it was triggered by the checkbox');
       if (stopPropagation) {
@@ -119,8 +113,8 @@ export class BaseTodoItems implements OnInit, OnDestroy {
     }
 
     console.log('Expanding element', element);
-    this.expandedElementId = this.expandedElementId === element.id ? undefined : element.id;
-    console.log('Expanded element', this.expandedElementId);
+    this.expandedElementId.set(this.expandedElementId() === element.id ? undefined : element.id);
+    console.log('Expanded element', this.expandedElementId());
     if (stopPropagation) {
       console.log('Stopping propagation');
       event.stopPropagation();
@@ -129,7 +123,7 @@ export class BaseTodoItems implements OnInit, OnDestroy {
 
   handleHideTasks(event: MatSlideToggleChange) {
     console.log('Hide completed tasks', event);
-    this.hideCompletedTasks = event.checked;
+    this.hideCompletedTasks.set(event.checked);
     this.getTodoItems();
   }
 

--- a/src/app/components/create-item-dialog/create-item-dialog.html
+++ b/src/app/components/create-item-dialog/create-item-dialog.html
@@ -49,12 +49,12 @@
         <mat-divider />
         <div formGroupName="prUrls">
           <button mat-flat-button type="button" (click)="addNewPrUrl()">Add New PR URL</button>
-          @if (this.prUrlsFormGroupAsArray.length === 0) {
+          @if (prUrlsFormGroupAsArray().length === 0) {
             <div>No PR URLs</div>
           }
-          @if (this.prUrlsFormGroupAsArray.length > 0) {
+          @if (prUrlsFormGroupAsArray().length > 0) {
             <mat-list role="list">
-              @for (item of getPrUrlFormControlsAsArray(); track item.name; let index = $index) {
+              @for (item of prUrlsFormGroupAsArray(); track item.name; let index = $index) {
                 <mat-list-item role="listitem"
                   ><mat-form-field>
                     <mat-label>PR Url</mat-label>
@@ -88,13 +88,13 @@
           <button mat-flat-button type="button" (click)="addNewTestingUrl()">
             Add New URL Used For Testing
           </button>
-          @if (this.urlsUsedForTestingFormGroupAsArray.length === 0) {
+          @if (urlsUsedForTestingFormGroupAsArray().length === 0) {
             <div>No URLs Used For Testing</div>
           }
-          @if (this.urlsUsedForTestingFormGroupAsArray.length > 0) {
+          @if (urlsUsedForTestingFormGroupAsArray().length > 0) {
             <mat-list role="list">
               @for (
-                item of urlsUsedForTestingFormGroupAsArray;
+                item of urlsUsedForTestingFormGroupAsArray();
                 track item.name;
                 let index = $index
               ) {

--- a/src/app/components/create-item-dialog/create-item-dialog.ts
+++ b/src/app/components/create-item-dialog/create-item-dialog.ts
@@ -1,5 +1,5 @@
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import {
   AbstractControl,
   FormControl,
@@ -66,9 +66,9 @@ export class CreateItemDialog {
   todoItemTypes = TODO_ITEM_TYPES;
 
   prUrlsFormGroup = new FormGroup<Record<string, AbstractControl<string | null>>>({});
-  prUrlsFormGroupAsArray: PrUrlFormGroupArray[] = [];
+  readonly prUrlsFormGroupAsArray = signal<PrUrlFormGroupArray[]>([]);
   urlsUsedForTestingFormGroup = new FormGroup<Record<string, AbstractControl<string | null>>>({});
-  urlsUsedForTestingFormGroupAsArray: TestingUrlFormGroupArray[] = [];
+  readonly urlsUsedForTestingFormGroupAsArray = signal<TestingUrlFormGroupArray[]>([]);
   createItemDialogForm = new FormGroup({
     titleFormControl: new FormControl<string>('', {
       nonNullable: true,
@@ -126,13 +126,7 @@ export class CreateItemDialog {
   }
 
   getPrUrlFormControlsAsArray(): PrUrlFormGroupArray[] {
-    const keys = Object.keys(this.prUrlsFormGroup.controls);
-    const returnValue = [];
-    for (const key of keys) {
-      returnValue.push({ name: key, control: this.prUrlsFormGroup.controls[key] });
-    }
-    this.prUrlsFormGroupAsArray = returnValue;
-    return returnValue;
+    return this.prUrlsFormGroupAsArray();
   }
 
   addNewPrUrl() {
@@ -140,32 +134,22 @@ export class CreateItemDialog {
       const newFormControlName = 'prUrlFormControl' + this.nextPrUrlIdNum++;
       const newFormControl = new FormControl<string | null>(null);
       this.prUrlsFormGroup.addControl(newFormControlName, newFormControl);
-      this.prUrlsFormGroupAsArray.push({
-        name: newFormControlName,
-        control: newFormControl,
-      });
+      this.prUrlsFormGroupAsArray.update((arr) => [
+        ...arr,
+        { name: newFormControlName, control: newFormControl },
+      ]);
     }, 0);
   }
 
   removePrUrl(formControlName: string) {
     this.prUrlsFormGroup.removeControl(formControlName);
-    const index = this.prUrlsFormGroupAsArray.findIndex((prUrl) => prUrl.name === formControlName);
-    if (index !== -1) {
-      this.prUrlsFormGroupAsArray.splice(index, 1);
-    }
+    this.prUrlsFormGroupAsArray.update((arr) =>
+      arr.filter((item) => item.name !== formControlName),
+    );
   }
 
   getUrlsUsedForTestingFormControlsAsArray(): TestingUrlFormGroupArray[] {
-    const keys = Object.keys(this.urlsUsedForTestingFormGroup.controls);
-    const returnValue = [];
-    for (const key of keys) {
-      returnValue.push({
-        name: key,
-        control: this.urlsUsedForTestingFormGroup.controls[key],
-      });
-    }
-    this.urlsUsedForTestingFormGroupAsArray = returnValue;
-    return returnValue;
+    return this.urlsUsedForTestingFormGroupAsArray();
   }
 
   addNewTestingUrl() {
@@ -173,20 +157,17 @@ export class CreateItemDialog {
       const newFormControlName = 'testingUrlFormControl' + this.nextTestingUrlIdNum++;
       const newFormControl = new FormControl<string | null>(null);
       this.urlsUsedForTestingFormGroup.addControl(newFormControlName, newFormControl);
-      this.urlsUsedForTestingFormGroupAsArray.push({
-        name: newFormControlName,
-        control: newFormControl,
-      });
+      this.urlsUsedForTestingFormGroupAsArray.update((arr) => [
+        ...arr,
+        { name: newFormControlName, control: newFormControl },
+      ]);
     }, 0);
   }
 
   removeTestingUrl(formControlName: string) {
     this.urlsUsedForTestingFormGroup.removeControl(formControlName);
-    const index = this.urlsUsedForTestingFormGroupAsArray.findIndex(
-      (testingUrl) => testingUrl.name === formControlName,
+    this.urlsUsedForTestingFormGroupAsArray.update((arr) =>
+      arr.filter((item) => item.name !== formControlName),
     );
-    if (index !== -1) {
-      this.urlsUsedForTestingFormGroupAsArray.splice(index, 1);
-    }
   }
 }

--- a/src/app/components/navigation/navigation.html
+++ b/src/app/components/navigation/navigation.html
@@ -1,4 +1,4 @@
-<div class="example-container" [class.example-is-mobile]="mobileQuery.matches">
+<div class="example-container" [class.example-is-mobile]="mobileMatches()">
   <mat-toolbar class="example-toolbar">
     <button mat-icon-button (click)="snav.toggle()"><mat-icon>menu</mat-icon></button>
     <h1 class="example-app-name">TODO Items</h1>
@@ -6,12 +6,12 @@
 
   <mat-sidenav-container
     class="example-sidenav-container"
-    [style.marginTop.px]="mobileQuery.matches ? 56 : 0"
+    [style.marginTop.px]="mobileMatches() ? 56 : 0"
   >
     <mat-sidenav
       #snav
-      [mode]="mobileQuery.matches ? 'over' : 'side'"
-      [fixedInViewport]="mobileQuery.matches"
+      [mode]="mobileMatches() ? 'over' : 'side'"
+      [fixedInViewport]="mobileMatches()"
       fixedTopGap="56"
     >
       <mat-nav-list>

--- a/src/app/components/navigation/navigation.ts
+++ b/src/app/components/navigation/navigation.ts
@@ -1,5 +1,5 @@
 import { MediaMatcher } from '@angular/cdk/layout';
-import { ChangeDetectorRef, Component, OnDestroy, inject } from '@angular/core';
+import { Component, OnDestroy, inject, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -30,8 +30,9 @@ export interface NavItem {
 })
 export class Navigation implements OnDestroy {
   mobileQuery: MediaQueryList;
+  readonly mobileMatches = signal(false);
 
-  navLinks: NavItem[] = [
+  readonly navLinks: NavItem[] = [
     { link: '/', display: 'Home' },
     { link: '/archive', display: 'Archive' },
   ];
@@ -39,11 +40,11 @@ export class Navigation implements OnDestroy {
   private _mobileQueryListener: (event: MediaQueryListEvent) => void;
 
   constructor() {
-    const changeDetectorRef = inject(ChangeDetectorRef);
     const media = inject(MediaMatcher);
 
     this.mobileQuery = media.matchMedia('(max-width: 600px)');
-    this._mobileQueryListener = () => changeDetectorRef.detectChanges();
+    this.mobileMatches.set(this.mobileQuery.matches);
+    this._mobileQueryListener = () => this.mobileMatches.set(this.mobileQuery.matches);
     try {
       this.mobileQuery.addEventListener('change', this._mobileQueryListener);
     } catch (e) {

--- a/src/app/pages/todo-items/todo-items.html
+++ b/src/app/pages/todo-items/todo-items.html
@@ -5,8 +5,8 @@
     <button mat-flat-button (click)="openDialog()">Create New Task</button>
   </div>
   <div>
-    <p>PIs: {{ pis }}</p>
-    <p>Sprints: {{ sprints }}</p>
+    <p>PIs: {{ pis() }}</p>
+    <p>Sprints: {{ sprints() }}</p>
   </div>
   <app-base-todo-items
     title="TODO Items"

--- a/src/app/pages/todo-items/todo-items.spec.ts
+++ b/src/app/pages/todo-items/todo-items.spec.ts
@@ -68,28 +68,28 @@ describe('TodoItemsPage', () => {
   });
 
   it('should initialize with empty pis and sprints', () => {
-    expect(component.pis).toEqual([]);
-    expect(component.sprints).toEqual([]);
+    expect(component.pis()).toEqual([]);
+    expect(component.sprints()).toEqual([]);
   });
 
   describe('setPis', () => {
     it('should update the pis array', () => {
       component.setPis(['PI1', 'PI2']);
-      expect(component.pis).toEqual(['PI1', 'PI2']);
+      expect(component.pis()).toEqual(['PI1', 'PI2']);
     });
   });
 
   describe('setSprints', () => {
     it('should update the sprints array', () => {
       component.setSprints([1, 2, 3]);
-      expect(component.sprints).toEqual([1, 2, 3]);
+      expect(component.sprints()).toEqual([1, 2, 3]);
     });
   });
 
   describe('openDialog', () => {
     it('should open CreateItemDialog with the current pis and sprints', () => {
-      component.pis = ['PI1'];
-      component.sprints = [1];
+      component.pis.set(['PI1']);
+      component.sprints.set([1]);
       mockDialog(undefined);
 
       component.openDialog();
@@ -132,21 +132,21 @@ describe('TodoItemsPage', () => {
     });
 
     it('should append the returned PI to the pis array', () => {
-      component.pis = ['PI1'];
+      component.pis.set(['PI1']);
       mockDialog('PI2');
 
       component.openNewPiDialog();
 
-      expect(component.pis).toEqual(['PI1', 'PI2']);
+      expect(component.pis()).toEqual(['PI1', 'PI2']);
     });
 
     it('should not modify pis when the dialog is cancelled', () => {
-      component.pis = ['PI1'];
+      component.pis.set(['PI1']);
       mockDialog(undefined);
 
       component.openNewPiDialog();
 
-      expect(component.pis).toEqual(['PI1']);
+      expect(component.pis()).toEqual(['PI1']);
     });
   });
 
@@ -160,39 +160,39 @@ describe('TodoItemsPage', () => {
     });
 
     it('should append a numeric result to the sprints array', () => {
-      component.sprints = [1];
+      component.sprints.set([1]);
       mockDialog(2);
 
       component.openNewSprintDialog();
 
-      expect(component.sprints).toEqual([1, 2]);
+      expect(component.sprints()).toEqual([1, 2]);
     });
 
     it('should parse a string result to a number before appending', () => {
-      component.sprints = [];
+      component.sprints.set([]);
       mockDialog('3');
 
       component.openNewSprintDialog();
 
-      expect(component.sprints).toEqual([3]);
+      expect(component.sprints()).toEqual([3]);
     });
 
     it('should not modify sprints when the dialog is cancelled (undefined result)', () => {
-      component.sprints = [1];
+      component.sprints.set([1]);
       mockDialog(undefined);
 
       component.openNewSprintDialog();
 
-      expect(component.sprints).toEqual([1]);
+      expect(component.sprints()).toEqual([1]);
     });
 
     it('should not modify sprints when result is NaN', () => {
-      component.sprints = [1];
+      component.sprints.set([1]);
       mockDialog('not-a-number');
 
       component.openNewSprintDialog();
 
-      expect(component.sprints).toEqual([1]);
+      expect(component.sprints()).toEqual([1]);
     });
   });
 });

--- a/src/app/pages/todo-items/todo-items.ts
+++ b/src/app/pages/todo-items/todo-items.ts
@@ -1,5 +1,5 @@
 import { DialogModule } from '@angular/cdk/dialog';
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
@@ -30,16 +30,16 @@ export class TodoItemsPage {
 
   readonly dialog = inject(MatDialog);
 
-  refreshTodoItems: Subject<void> = new Subject<void>();
-  pis: string[] = [];
-  sprints: number[] = [];
+  readonly refreshTodoItems: Subject<void> = new Subject<void>();
+  readonly pis = signal<string[]>([]);
+  readonly sprints = signal<number[]>([]);
 
   openDialog(): void {
     const dialogRef = this.dialog.open<CreateItemDialog, CreateItemDialogData, TodoItem>(
       CreateItemDialog,
       {
         width: '500px',
-        data: { pis: this.pis, sprints: this.sprints },
+        data: { pis: this.pis(), sprints: this.sprints() },
       },
     );
 
@@ -59,13 +59,13 @@ export class TodoItemsPage {
   openNewPiDialog(): void {
     const dialogRef = this.dialog.open<AddNewPiDialog, AddNewPiDialogData, string>(AddNewPiDialog, {
       width: '500px',
-      data: { pis: this.pis },
+      data: { pis: this.pis() },
     });
 
     dialogRef.afterClosed().subscribe((result) => {
       console.log('The add new PI dialog was closed', result);
       if (result) {
-        this.pis = [...this.pis, result];
+        this.pis.update((pis) => [...pis, result]);
       } else {
         console.log('No add new PI result');
       }
@@ -77,7 +77,7 @@ export class TodoItemsPage {
       AddNewSprintDialog,
       {
         width: '500px',
-        data: { sprints: this.sprints },
+        data: { sprints: this.sprints() },
       },
     );
 
@@ -87,7 +87,7 @@ export class TodoItemsPage {
         result = parseInt(result, 10);
       }
       if (result !== undefined && !isNaN(result)) {
-        this.sprints = [...this.sprints, result];
+        this.sprints.update((sprints) => [...sprints, result]);
       } else {
         console.log('No add new sprint result');
       }
@@ -95,10 +95,10 @@ export class TodoItemsPage {
   }
 
   setPis(pis: string[]): void {
-    this.pis = pis;
+    this.pis.set(pis);
   }
 
   setSprints(sprints: number[]): void {
-    this.sprints = sprints;
+    this.sprints.set(sprints);
   }
 }


### PR DESCRIPTION
Migrate component state in the todo pages, base todo list, navigation, and create-item dialog from mutable properties to Angular signals/computed values. This removes manual change detection and explicit refresh subscription cleanup in `BaseTodoItems`, updates templates and specs to the signal API, and drops unused dialog inputs from the add-PI and add-sprint dialogs.